### PR TITLE
Allow SimplePopulationEvaluator to evaluate _all_ sub-populations

### DIFF
--- a/eckity/evaluators/simple_population_evaluator.py
+++ b/eckity/evaluators/simple_population_evaluator.py
@@ -7,39 +7,43 @@ from eckity.individual import Individual
 
 
 class SimplePopulationEvaluator(PopulationEvaluator):
-	@overrides
-	def _evaluate(self, population):
-		"""
-		Updates the fitness score of the given individuals, then returns the best individual
+    def __init__(self,
+                 best_on: int = 0):
+        super().__init__()
+        self.best_on = best_on
 
-		Parameters
-		----------
-		population:
-			the population of the evolutionary experiment
+    @overrides
+    def _evaluate(self, population):
+        """
+        Updates the fitness score of the given individuals, then returns the best individual
 
-		Returns
-		-------
-		individual
-			the individual with the best fitness out of the given individuals
-		"""
-		super()._evaluate(population)
-		for sub_population in population.sub_populations:
-			sub_population = population.sub_populations[0]
-			sp_eval: IndividualEvaluator = sub_population.evaluator
-			eval_results = self.executor.map(sp_eval.evaluate_individual, sub_population.individuals)
-			for ind, fitness_score in zip(sub_population.individuals, eval_results):
-				ind.fitness.set_fitness(fitness_score)
+        Parameters
+        ----------
+        population:
+            the population of the evolutionary experiment
 
+        Returns
+        -------
+        individual
+            the individual with the best fitness out of the given individuals
+        """
+        super()._evaluate(population)
+        for sub_population in population.sub_populations:
+            sp_eval: IndividualEvaluator = sub_population.evaluator
+            eval_results = self.executor.map(sp_eval.evaluate_individual, sub_population.individuals)
+            for ind, fitness_score in zip(sub_population.individuals, eval_results):
+                ind.fitness.set_fitness(fitness_score)
 
-		# only one subpopulation in simple case
-		individuals = population.sub_populations[0].individuals
+        assert self.best_on <= len(
+            population.sub_populations), "Can't pick best solution on non-existing sub-population."
+        individuals = population.sub_populations[self.best_on].individuals
 
-		best_ind: Individual = population.sub_populations[0].individuals[0]
-		best_fitness: Fitness = best_ind.fitness
+        best_ind: Individual = population.sub_populations[self.best_on].individuals[self.best_on]
+        best_fitness: Fitness = best_ind.fitness
 
-		for ind in individuals[1:]:
-			if ind.fitness.better_than(ind, best_fitness, best_ind):
-				best_ind = ind
-				best_fitness = ind.fitness
+        for ind in individuals[1:]:
+            if ind.fitness.better_than(ind, best_fitness, best_ind):
+                best_ind = ind
+                best_fitness = ind.fitness
 
-		return best_ind
+        return best_ind

--- a/eckity/evaluators/simple_population_evaluator.py
+++ b/eckity/evaluators/simple_population_evaluator.py
@@ -34,8 +34,7 @@ class SimplePopulationEvaluator(PopulationEvaluator):
             for ind, fitness_score in zip(sub_population.individuals, eval_results):
                 ind.fitness.set_fitness(fitness_score)
 
-        assert self.best_on <= len(
-            population.sub_populations), "Can't pick best solution on non-existing sub-population."
+        assert self.best_on < len(population.sub_populations), "Can't pick best solution on non-existing sub-population."
         individuals = population.sub_populations[self.best_on].individuals
 
         best_ind: Individual = population.sub_populations[self.best_on].individuals[self.best_on]


### PR DESCRIPTION
Previous code had 
```
for sub_population in population.sub_populations:
    sub_population = population.sub_populations[0]
    ...
```
So only one subpopulation was ever really evaluated. I've also added the option to choose from which population the best individual should be picked (`best_on` parameter with default value set to `0`).