### PR TITLE
elitism: have at least one individual if user requested more than 0

### DIFF
--- a/eckity/subpopulation.py
+++ b/eckity/subpopulation.py
@@ -1,4 +1,5 @@
 import random
+import math
 import numpy as np
 
 from eckity.creators.creator import Creator
@@ -112,7 +113,7 @@ class Subpopulation:
         self.higher_is_better = higher_is_better
         self.evaluator = evaluator
 
-        self.n_elite = round(elitism_rate * self.population_size)
+        self.n_elite = math.ceil(elitism_rate * self.population_size)   # if the user requested more than 0, give them at least 1
         self.individuals = individuals
 
     def create_subpopulation_individuals(self):


### PR DESCRIPTION
e.g., if the population is 100, and user asked for 0.005 elitism, then previously it will be `int(100*0.005)` which is 0.
But if the user bothered to have a non zero elitism value, he probably expects at least one.