### PR TITLE
termination_checker: added best_fitness_stagnation_termination_checker

### DIFF
--- a/eckity/termination_checkers/best_fitness_stagnation_termination_checker.py
+++ b/eckity/termination_checkers/best_fitness_stagnation_termination_checker.py
@@ -16,7 +16,7 @@ class BestFitnessStagnationTerminationChecker(TerminationChecker):
     def __init__(self, stagnation_generations_to_terminate=100):
         super().__init__()
         self.stagnation_generations_to_terminate = stagnation_generations_to_terminate
-        self.best_fitness = float('inf')
+        self.best_fitnesses = None
         self.stagnation_generations = 0
 
     def should_terminate(self, population, best_individual, gen_number):
@@ -30,7 +30,7 @@ class BestFitnessStagnationTerminationChecker(TerminationChecker):
             The evolutionary experiment population of individuals.
 
         best_individual: Individual
-            The individual that has the best fitness of the current generation.
+            The individual that has the best fitness of the algorithm.
 
         gen_number: int
             Current generation number.
@@ -40,10 +40,11 @@ class BestFitnessStagnationTerminationChecker(TerminationChecker):
         bool
             True if the algorithm should terminate early, False otherwise.
         """
-        if math.isclose(best_individual.get_pure_fitness(), self.best_fitness):
+        best_fitnesses = [ind.get_pure_fitness() for ind in population.get_best_individuals()]
+        if self.best_fitnesses and all([math.isclose(a, b) for a, b in zip(best_fitnesses, self.best_fitnesses)]):
             self.stagnation_generations += 1
             return self.stagnation_generations >= self.stagnation_generations_to_terminate
         else:
             self.stagnation_generations = 0
-            self.best_fitness = best_individual.get_pure_fitness()
+            self.best_fitnesses = best_fitnesses
             return False

--- a/eckity/termination_checkers/best_fitness_stagnation_termination_checker.py
+++ b/eckity/termination_checkers/best_fitness_stagnation_termination_checker.py
@@ -1,0 +1,49 @@
+import math
+
+from eckity.termination_checkers.termination_checker import TerminationChecker
+
+
+class BestFitnessStagnationTerminationChecker(TerminationChecker):
+    """
+    Concrete Termination Checker that checks that best firnes.
+
+    Parameters
+    ----------
+    stagnation_generations: int, default=100.
+        This termination checker checks if the best fitness hasn't changed for stagnation_generations generations.
+    """
+
+    def __init__(self, stagnation_generations_to_terminate=100):
+        super().__init__()
+        self.stagnation_generations_to_terminate = stagnation_generations_to_terminate
+        self.best_fitness = float('inf')
+        self.stagnation_generations = 0
+
+    def should_terminate(self, population, best_individual, gen_number):
+        """
+        Determines if the best fitness hasn't changed for stagnation_generations generations.
+        If so, recommends the algorithm to terminate early.
+
+        Parameters
+        ----------
+        population: Population
+            The evolutionary experiment population of individuals.
+
+        best_individual: Individual
+            The individual that has the best fitness of the current generation.
+
+        gen_number: int
+            Current generation number.
+
+        Returns
+        -------
+        bool
+            True if the algorithm should terminate early, False otherwise.
+        """
+        if math.isclose(best_individual.get_pure_fitness(), self.best_fitness):
+            self.stagnation_generations += 1
+            return self.stagnation_generations >= self.stagnation_generations_to_terminate
+        else:
+            self.stagnation_generations = 0
+            self.best_fitness = best_individual.get_pure_fitness()
+            return False


### PR DESCRIPTION
Note that this uses `math.isclose` which was introduced at Python 3.5.
I assume that it's OK, but if not - it can be replaced with some other code.
Anyway, is there a definition of minimal supported Python version?