### PR TITLE
fixes in Fitness classes

### DIFF
--- a/eckity/fitness/fitness.py
+++ b/eckity/fitness/fitness.py
@@ -2,47 +2,42 @@
 This module implements the class `Fitness`
 """
 
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 
 
-class Fitness:
+class Fitness(ABC):
     """
     This class is responsible for handling the fitness score of some Individual
     (checking if fitness is evaluated, comparing fitness scores with other individuals etc.)
 
-    context: list of Individuals
-        individuals involved in calculating the fitness (co-evolution)
-
-    trials: list of floats
-        fitness results for previous trials done to calculate fitness (co-evolution)
-
-    _is_evaluated: bool
+    is_evaluated: bool
         declares if fitness score is evaluated and updated in the current generation
-
-    is_relative_fitness: bool
-        declares whether the fitness score is absolute or relative
-
-    should_cache_between_gens: bool
-        declares whether the fitness score should reset at the end of each generation
 
     higher_is_better: bool
         declares the fitness direction.
         i.e., if it should be minimized or maximized
+
+    cache: bool
+        declares whether the fitness score should reset at the end of each generation
+
+    is_relative_fitness: bool
+        declares whether the fitness score is absolute or relative
     """
-    def __init__(self,
-                 context=None,
-                 trials=None,
-                 is_evaluated=False,
-                 is_relative_fitness=False,
-                 should_cache_between_gens=True,
-                 higher_is_better=False):
-        self.context = context
-        self.trials = trials
+
+    def __init__(
+        self,
+        is_evaluated: bool = False,
+        higher_is_better: bool = None,
+        is_relative_fitness: bool = False,
+        cache: bool = False,
+    ):
         self._is_evaluated = is_evaluated
         self.is_relative_fitness = is_relative_fitness
-        self.should_cache_between_gens = False if is_relative_fitness else should_cache_between_gens
+        self.cache = False if is_relative_fitness else cache
+
+        if higher_is_better is None:
+            raise ValueError("higher_is_better must be set to True/False")
         self.higher_is_better = higher_is_better
-        self.optimal_fitness = 1 if higher_is_better else 0
 
     @abstractmethod
     def get_pure_fitness(self):

--- a/eckity/fitness/gp_fitness.py
+++ b/eckity/fitness/gp_fitness.py
@@ -22,14 +22,30 @@ class GPFitness(SimpleFitness):
         declares the fitness direction.
         i.e., if it should be minimized or maximized
 
+    cache: bool
+        declares whether the fitness score should reset at the end of each generation
+
+    is_relative_fitness: bool
+        declares whether the fitness score is absolute or relative
+
     bloat_weight: float
         the weight of the bloat control fitness reduction
     """
-    def __init__(self,
-                 fitness: float = None,
-                 higher_is_better=False,
-                 bloat_weight=0.1):
-        super().__init__(fitness=fitness, higher_is_better=higher_is_better)
+
+    def __init__(
+        self,
+        fitness: float = None,
+        higher_is_better: bool = False,
+        cache: bool = False,
+        is_relative_fitness: bool = False,
+        bloat_weight: float = 0.1,
+    ):
+        super().__init__(
+            fitness=fitness,
+            higher_is_better=higher_is_better,
+            cache=cache,
+            is_relative_fitness=is_relative_fitness,
+        )
         self.bloat_weight = bloat_weight
 
     @overrides
@@ -47,11 +63,12 @@ class GPFitness(SimpleFitness):
         float
             augmented fitness score after applying bloat control
         """
-        if not self.is_fitness_evaluated():
-            raise ValueError('Fitness not evaluated yet')
+        score = self.get_pure_fitness()
 
         # subtract bloat value from the fitness score if it should be maximized,
         # otherwise add bloat value to fitness score
-        return self.fitness - self.bloat_weight * individual.size() \
-            if self.higher_is_better \
-            else self.fitness + self.bloat_weight * individual.size()
+        return (
+            score - self.bloat_weight * individual.size()
+            if self.higher_is_better
+            else score + self.bloat_weight * individual.size()
+        )

--- a/eckity/fitness/simple_fitness.py
+++ b/eckity/fitness/simple_fitness.py
@@ -1,7 +1,4 @@
-from overrides import overrides
-"""
-This module implements the class `SimpleFitness`
-"""
+from overrides import override
 
 from eckity.fitness.fitness import Fitness
 
@@ -19,12 +16,28 @@ class SimpleFitness(Fitness):
     higher_is_better: bool
         declares the fitness direction.
         i.e., if it should be minimized or maximized
+
+    cache: bool
+        declares whether the fitness score should reset at the end of each generation
+
+    is_relative_fitness: bool
+        declares whether the fitness score is absolute or relative
     """
-    def __init__(self,
-                 fitness: float = None,
-                 higher_is_better=False):
+
+    def __init__(
+        self,
+        fitness: float = None,
+        higher_is_better: bool = False,
+        cache: bool = False,
+        is_relative_fitness: bool = False,
+    ):
         is_evaluated = fitness is not None
-        super().__init__(higher_is_better=higher_is_better, is_evaluated=is_evaluated)
+        super().__init__(
+            higher_is_better=higher_is_better,
+            is_evaluated=is_evaluated,
+            cache=cache,
+            is_relative_fitness=is_relative_fitness,
+        )
         self.fitness: float = fitness
 
     def set_fitness(self, fitness):
@@ -39,7 +52,7 @@ class SimpleFitness(Fitness):
         self.fitness = fitness
         self._is_evaluated = True
 
-    @overrides
+    @override
     def get_pure_fitness(self):
         """
         Returns the pure fitness score of the individual (before applying balancing methods like bloat control)
@@ -50,10 +63,10 @@ class SimpleFitness(Fitness):
             fitness score of the individual
         """
         if not self._is_evaluated:
-            raise ValueError('Fitness not evaluated yet')
+            raise ValueError("Fitness not evaluated yet")
         return self.fitness
 
-    @overrides
+    @override
     def set_not_evaluated(self):
         """
         Set this fitness score status to be not evaluated
@@ -71,11 +84,13 @@ class SimpleFitness(Fitness):
             True if fitness scores are comparable, False otherwise
         """
         if not isinstance(other_fitness, SimpleFitness):
-            raise TypeError('Expected SimpleFitness object in better_than, got', type(other_fitness))
+            raise TypeError(
+                "Expected SimpleFitness object in better_than, got", type(other_fitness)
+            )
         if not self.is_fitness_evaluated() or not other_fitness.is_fitness_evaluated():
-            raise ValueError('Fitness scores must be evaluated before comparison')
+            raise ValueError("Fitness scores must be evaluated before comparison")
 
-    @overrides
+    @override
     def better_than(self, ind, other_fitness, other_ind):
         """
         Compares between the current fitness of the individual `ind` to the fitness score `other_fitness` of `other_ind`
@@ -98,11 +113,15 @@ class SimpleFitness(Fitness):
             True if this fitness score is better than the `other` fitness score, False otherwise
         """
         self.check_comparable_fitness_scores(other_fitness)
-        return self.get_augmented_fitness(ind) > other_fitness.get_augmented_fitness(other_ind) \
-            if self.higher_is_better \
-            else self.get_augmented_fitness(ind) < other_fitness.get_augmented_fitness(other_ind)
+        return (
+            self.get_augmented_fitness(ind)
+            > other_fitness.get_augmented_fitness(other_ind)
+            if self.higher_is_better
+            else self.get_augmented_fitness(ind)
+            < other_fitness.get_augmented_fitness(other_ind)
+        )
 
-    @overrides
+    @override
     def equal_to(self, ind, other_fitness, other_ind):
         """
         Compares between the current fitness of the individual `ind` to the fitness score `other_fitness` of `other_ind`
@@ -125,11 +144,13 @@ class SimpleFitness(Fitness):
             True if this fitness score is equal to the `other` fitness score, False otherwise
         """
         self.check_comparable_fitness_scores(other_fitness)
-        return self.get_augmented_fitness(ind) == other_fitness.get_augmented_fitness(other_ind)
+        return self.get_augmented_fitness(ind) == other_fitness.get_augmented_fitness(
+            other_ind
+        )
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        if not self.should_cache_between_gens:
-            state['_is_evaluated'] = False
-            state['fitness'] = None
+        if not self.cache:
+            state["_is_evaluated"] = False
+            state["fitness"] = None
         return state

--- a/eckity/genetic_encodings/ga/tests/test_bit_string_vector.py
+++ b/eckity/genetic_encodings/ga/tests/test_bit_string_vector.py
@@ -85,7 +85,9 @@ class TestBitStringVector:
     def test_clone(self):
         cells = [0, 1]
         score = 0.1
-        v1 = BitStringVector(SimpleFitness(score), len(cells), vector=cells)
+        v1 = BitStringVector(SimpleFitness(score, cache=True),
+                             length=len(cells),
+                             vector=cells)
 
         v2 = v1.clone()
         assert v2.vector == v1.vector

--- a/eckity/genetic_encodings/ga/tests/test_float_vector.py
+++ b/eckity/genetic_encodings/ga/tests/test_float_vector.py
@@ -5,42 +5,44 @@ from eckity.genetic_encodings.ga.float_vector import FloatVector
 
 
 class TestFloatVector:
-	def test_vector_direct_initialization(self):
-		length = 5
-		cells = [0., 0., 1., 1., 1.]
-		vec = FloatVector(SimpleFitness(), length=length,vector=cells)
-		assert len(vec.vector) == length
-		assert vec.vector == cells
-	
-	def test_bad_bounds(self):
-		length = 5
-		bounds = [(i, i + 1) for i in range(length)]
+    def test_vector_direct_initialization(self):
+        length = 5
+        cells = [0.0, 0.0, 1.0, 1.0, 1.0]
+        vec = FloatVector(SimpleFitness(), length=length, vector=cells)
+        assert len(vec.vector) == length
+        assert vec.vector == cells
 
-		with pytest.raises(ValueError):
-			FloatVector(SimpleFitness(), bounds=bounds, length=length + 1)
-		with pytest.raises(ValueError):
-			FloatVector(SimpleFitness(), bounds=bounds, length=length - 1)
+    def test_bad_bounds(self):
+        length = 5
+        bounds = [(i, i + 1) for i in range(length)]
 
-	def test_get_vector_part_last_cell(self):
-		length = 4
-		vec = FloatVector(SimpleFitness(), length, bounds=(1, 10))
+        with pytest.raises(ValueError):
+            FloatVector(SimpleFitness(), bounds=bounds, length=length + 1)
+        with pytest.raises(ValueError):
+            FloatVector(SimpleFitness(), bounds=bounds, length=length - 1)
 
-		vec.set_vector(list(range(1, 5)))
-		assert vec.get_vector_part(length - 1, length) == [4]
+    def test_get_vector_part_last_cell(self):
+        length = 4
+        vec = FloatVector(SimpleFitness(), length, bounds=(1, 10))
 
-	def test_clone(self):
-		cells = [1., 2.]
-		score = 0.1
-		v1 = FloatVector(SimpleFitness(score), len(cells), vector=cells)
+        vec.set_vector(list(range(1, 5)))
+        assert vec.get_vector_part(length - 1, length) == [4]
 
-		v2 = v1.clone()
-		assert v2.vector == v1.vector
-		assert v2.length == v1.length
-		assert v2.bounds == v1.bounds
-		assert v2.get_pure_fitness() == v1.get_pure_fitness()
-		assert v1.id == v2.id - 1
-		assert v2.cloned_from == [v1.id]
+    def test_clone(self):
+        cells = [1.0, 2.0]
+        score = 0.1
+        v1 = FloatVector(SimpleFitness(score, cache=True),
+                         length=len(cells),
+                         vector=cells)
 
-		# Check that fitness is evaluated and equal to original one
-		assert v2.fitness.get_pure_fitness() == score
-		assert v2.fitness.is_fitness_evaluated()
+        v2 = v1.clone()
+        assert v2.vector == v1.vector
+        assert v2.length == v1.length
+        assert v2.bounds == v1.bounds
+        assert v2.get_pure_fitness() == v1.get_pure_fitness()
+        assert v1.id == v2.id - 1
+        assert v2.cloned_from == [v1.id]
+
+        # Check that fitness is evaluated and equal to original one
+        assert v2.fitness.get_pure_fitness() == score
+        assert v2.fitness.is_fitness_evaluated()

--- a/eckity/genetic_encodings/ga/tests/test_int_vector.py
+++ b/eckity/genetic_encodings/ga/tests/test_int_vector.py
@@ -5,61 +5,60 @@ from eckity.genetic_encodings.ga.int_vector import IntVector
 
 
 class TestIntVector:
-	def test_vector_direct_initialization(self):
-		length = 5
-		cells = [0, 1, 1, 1, 3]
-		vec = IntVector(SimpleFitness(), length=length, vector=cells)
-		assert len(vec.vector) == length
-		assert vec.vector == cells
-	
-	def test_bad_bounds(self):
-		length = 5
-		bounds = [(i, i + 1) for i in range(length)]
+    def test_vector_direct_initialization(self):
+        length = 5
+        cells = [0, 1, 1, 1, 3]
+        vec = IntVector(SimpleFitness(), length=length, vector=cells)
+        assert len(vec.vector) == length
+        assert vec.vector == cells
 
-		with pytest.raises(ValueError):
-			IntVector(SimpleFitness(), bounds=bounds, length=length + 1)
-		with pytest.raises(ValueError):
-			IntVector(SimpleFitness(), bounds=bounds, length=length - 1)
+    def test_bad_bounds(self):
+        length = 5
+        bounds = [(i, i + 1) for i in range(length)]
 
-	def test_int_get_rand_num_single_bounds(self):
-		bounds = (1, 5)
-		vec1 = IntVector(SimpleFitness(), bounds=bounds, length=5)
+        with pytest.raises(ValueError):
+            IntVector(SimpleFitness(), bounds=bounds, length=length + 1)
+        with pytest.raises(ValueError):
+            IntVector(SimpleFitness(), bounds=bounds, length=length - 1)
 
-		for _ in range(10 ** 3):
-			num = vec1.get_random_number_in_bounds(0)
-			assert type(num) == int and bounds[0] <= num <= bounds[1]
+    def test_int_get_rand_num_single_bounds(self):
+        bounds = (1, 5)
+        vec1 = IntVector(SimpleFitness(), bounds=bounds, length=5)
 
-	def test_int_get_rand_num_multi_bounds(self):
-		length = 5
-		bounds = [(i, i + 1) for i in range(length)]
-		vec1 = IntVector(SimpleFitness(), bounds=bounds, length=length)
+        for _ in range(10**3):
+            num = vec1.get_random_number_in_bounds(0)
+            assert isinstance(num, int) and bounds[0] <= num <= bounds[1]
 
-		for i in range(length):
-			num = vec1.get_random_number_in_bounds(i)
-			assert type(num) == int and bounds[i][0] <= num <= bounds[i][1]
+    def test_int_get_rand_num_multi_bounds(self):
+        length = 5
+        bounds = [(i, i + 1) for i in range(length)]
+        vec1 = IntVector(SimpleFitness(), bounds=bounds, length=length)
 
-	def test_get_vector_part_last_cell(self):
-		length = 4
-		v1 = IntVector(SimpleFitness(), length, bounds=(1, 10))
-		v1.set_vector(list(range(1, 5)))
-		assert v1.get_vector_part(length - 1, length) == [4]
+        for i in range(length):
+            num = vec1.get_random_number_in_bounds(i)
+            assert isinstance(num, int) and bounds[i][0] <= num <= bounds[i][1]
 
-	def test_clone(self):
-		cells = [0, 1]
-		score = 0.1
-		v1 = IntVector(SimpleFitness(score), len(cells), vector=cells)
+    def test_get_vector_part_last_cell(self):
+        length = 4
+        v1 = IntVector(SimpleFitness(), length, bounds=(1, 10))
+        v1.set_vector(list(range(1, 5)))
+        assert v1.get_vector_part(length - 1, length) == [4]
 
-		v2 = v1.clone()
-		assert v2.vector == v1.vector
-		assert v2.length == v1.length
-		assert v2.bounds == v1.bounds
-		assert v2.get_pure_fitness() == v1.get_pure_fitness()
-		assert v1.id == v2.id - 1
-		assert v2.cloned_from == [v1.id]
+    def test_clone(self):
+        cells = [0, 1]
+        score = 0.1
+        v1 = IntVector(SimpleFitness(score, cache=True),
+                       length=len(cells),
+                       vector=cells)
 
-		# Check that fitness is evaluated and equal to original one
-		assert v2.fitness.get_pure_fitness() == score
-		assert v2.fitness.is_fitness_evaluated()
+        v2 = v1.clone()
+        assert v2.vector == v1.vector
+        assert v2.length == v1.length
+        assert v2.bounds == v1.bounds
+        assert v2.get_pure_fitness() == v1.get_pure_fitness()
+        assert v1.id == v2.id - 1
+        assert v2.cloned_from == [v1.id]
 
-
-
+        # Check that fitness is evaluated and equal to original one
+        assert v2.fitness.get_pure_fitness() == score
+        assert v2.fitness.is_fitness_evaluated()


### PR DESCRIPTION
- removed unused `context` and `trials` fields from `Fitness` (these can be added when Coevolution will be added to the package, if they will be necessary)
- renamed `should_cache_between_gens` field to `cache`
- added `cache` and `is_relative_fitness` arguments to `SimpleFitness` and `GPFitness` constructor (those fields were inaccessible previously).