### PR TITLE
Remove default termination

### DIFF
--- a/eckity/algorithms/algorithm.py
+++ b/eckity/algorithms/algorithm.py
@@ -16,6 +16,7 @@ from eckity import Population, Subpopulation
 from eckity.breeders import Breeder
 from eckity.evaluators import PopulationEvaluator
 from eckity.event_based_operator import Operator
+from eckity.individual import Individual
 from eckity.random import RNG
 from eckity.statistics.statistics import Statistics
 from eckity.termination_checkers import TerminationChecker
@@ -396,7 +397,12 @@ class Algorithm(Operator, ABC):
         """
         return (self.generation_seed + 1) % (2**32)
 
-    def should_terminate(self, population, best_of_run_, generation_num):
+    def should_terminate(
+        self,
+        population: Population,
+        best_of_run_: Individual,
+        generation_num: int,
+    ) -> bool:
         if self.termination_checker is None:
             return False
         elif isinstance(self.termination_checker, list):

--- a/eckity/algorithms/algorithm.py
+++ b/eckity/algorithms/algorithm.py
@@ -67,7 +67,7 @@ class Algorithm(Operator, ABC):
         Names of events to publish during the evolution.
 
     termination_checker: TerminationChecker or a list of TerminationCheckers,
-                          default=ThresholdFromTargetTerminationChecker()
+                          default=None
         Checks if the algorithm should terminate early.
         ref: https://api.eckity.org/eckity/termination_checkers.html
 
@@ -397,7 +397,9 @@ class Algorithm(Operator, ABC):
         return (self.generation_seed + 1) % (2**32)
 
     def should_terminate(self, population, best_of_run_, generation_num):
-        if isinstance(self.termination_checker, list):
+        if self.termination_checker is None:
+            return False
+        elif isinstance(self.termination_checker, list):
             return any(
                 [
                     t.should_terminate(

--- a/eckity/algorithms/simple_evolution.py
+++ b/eckity/algorithms/simple_evolution.py
@@ -51,8 +51,7 @@ class SimpleEvolution(Algorithm):
     event_names: list of strings, default=None
             Names of events to publish during the evolution.
 
-    termination_checker: TerminationChecker,
-                         default=ThresholdFromTargetTerminationChecker()
+    termination_checker: TerminationChecker
             Checks if the evolution should perform early termination.
 
     max_workers: int, default=None
@@ -118,11 +117,6 @@ class SimpleEvolution(Algorithm):
 
         if breeder is None:
             breeder = SimpleBreeder()
-
-        if termination_checker is None:
-            termination_checker = ThresholdFromTargetTerminationChecker(
-                threshold=0
-            )
         
         if population_evaluator is None:
             population_evaluator = SimplePopulationEvaluator()


### PR DESCRIPTION
The default `termination_checker` is `ThresholdFromTargetTerminationChecker` that terminates the run if the best fitness is 0.
This created a bug in a maximization problem where all individuals received a fitness score of 0, causing the run to end right after the initial generation.