### PR TITLE
fix: declare scipy dependency and pin jupyter-book for docs build

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -32,6 +32,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pdoc
+        python -m pip install -r requirements.txt
+        python -m pip install -r requirements-ml.txt --use-pep517
         python -m pip install -r docs/requirements.txt
 
     - name: Build documentation

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jupyter-book
+jupyter-book==1.0.3
 matplotlib
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy>=1.23.0
 overrides>=7.0.0
 pandas>=0.25.2
+scipy>=1.7.0
 

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     },
     license='GNU GPLv3',
     packages=find_packages(),
-    install_requires=["numpy>=1.23.0", "overrides>=7.0.0", "pandas>=0.25.2"],
+    install_requires=["numpy>=1.23.0", "overrides>=7.0.0", "pandas>=0.25.2", "scipy>=1.7.0"],
 )


### PR DESCRIPTION
scipy is imported directly by fp_selection.py and
classification_evaluator.py but was never declared in requirements.txt/setup.py, only working locally because scikit-learn pulled it in transitively. This broke pdoc in CI, which imports every eckity submodule to introspect docstrings.

Also pin jupyter-book==1.0.3 in docs/requirements.txt: leaving it unpinned let CI resolve the incompatible MyST-based v2 release, which uses a different (Node-backed) build command and failed immediately. gendocs.yml now also installs requirements.txt and requirements-ml.txt before building so pdoc can import sklearn_compatible as well.