### PR TITLE
fix: API reference link on docs landing page pointing to itself

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,7 +4,7 @@ EC-KitY is a Python tool kit for doing evolutionary computation, and it is sciki
 
 [Website](https://eckity.org) \
 [Paper](https://www.sciencedirect.com/science/article/pii/S2352711023000778) \
-[API reference](api/eckity.html) \
+<a href="api/eckity.html">API reference</a> \
 [Community section](https://chat.eckity.org)
 
 EC-KitY is:


### PR DESCRIPTION
MyST resolves relative markdown links ending in .html as internal cross-references unless they're a known page in the Sphinx build. Since api/eckity.html (pdoc's output) isn't part of the jupyter-book build tree, MyST silently degraded it to a same-page anchor (href="#api/eckity.html"), so the link just reloaded the landing page instead of navigating to the API reference.

Use a raw HTML anchor instead, which MyST passes through untouched.